### PR TITLE
Web3 Provider spec update

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/ProjectWyvern/wyvern-js#readme",
   "dependencies": {
     "0x.js": "^0.29.2",
+    "@0x/assert": "^3.0.30",
     "@0xproject/abi-gen": "^0.1.1",
     "@0xproject/assert": "^0.0.11",
     "@0xproject/json-schemas": "^0.7.3",

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,6 +1,6 @@
 /* Sourced from 0x.js */
 
-import { assert as sharedAssert } from '@0xproject/assert';
+import { assert as sharedAssert } from '@0x/assert';
 // We need those two unused imports because they're actually used by sharedAssert which gets injected here
 // tslint:disable-next-line:no-unused-variable
 import { Schema } from '@0xproject/json-schemas';


### PR DESCRIPTION
due to updates in the  [Web3 Provider spec](https://eips.ethereum.org/EIPS/eip-1193)

- [`0xProject/assert`](https://github.com/0xProject/0x-monorepo/blob/development/packages/assert/src/index.ts#L79) is out of sync 
- no longer maintained

Old assert checks for send & sendAsync, both of which have been deprecated

the new assert checks for request, the new method to be used to verify it is a web3Provider 


